### PR TITLE
Fix CallbackQuery id type

### DIFF
--- a/lib/telegram/bot/types/callback_query.rb
+++ b/lib/telegram/bot/types/callback_query.rb
@@ -4,7 +4,7 @@ module Telegram
   module Bot
     module Types
       class CallbackQuery < Base
-        attribute :id, String
+        attribute :id, Integer
         attribute :from, User
         attribute :message, Message
         attribute :inline_message_id, String


### PR DESCRIPTION
Hey there,
I found this issue when I have TypedUpdate (obiviously) and callback_query.

In specs:
```ruby
context 'callback query', :callback_query do
  let(:data) { 1 }

  it { should answer_callback_query 'response', show_alert: true }
end
```
I had the following error:
```ruby
Failure/Error: it { should answer_callback_query 'response', show_alert: true }
       expected to make exactly 1 #<Telegram::Bot::ClientStub#15120(6528843374:AAFdQwZwX0riQTOV4Lmz04s3-iTQdquJupk)>.answerCallbackQuery requests, with [#<RSpec::Mocks::ArgumentMatchers::HashIncludingMatcher:0x000000010a0fbcd8 @expected={:show_alert=>true, :callback_query_id=>11, :text=>"response"}>], but made 0, and 1 with {:show_alert=>true, :callback_query_id=>"11", :text=>"response"}
```

spec helpers expecting callback_query_id as Integer, while app returns string.

This PR fixes it, but I can make additional changes (if needed)